### PR TITLE
Add EPFL campus layout

### DIFF
--- a/app/src/main/java/com/github/polypoly/app/MapActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/MapActivity.kt
@@ -12,10 +12,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 import com.github.polypoly.app.ui.theme.PolypolyTheme
 import org.osmdroid.config.Configuration
+import org.osmdroid.tileprovider.MapTileProviderBasic
+import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
+import org.osmdroid.util.MapTileIndex
 import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.TilesOverlay
+import kotlin.random.Random
 
 class MapActivity : ComponentActivity() {
 
@@ -42,6 +47,10 @@ class MapActivity : ComponentActivity() {
 
             val mapView = MapView(context)
             mapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE)
+            val campusTileSource = CampusTileSource(Random.nextInt(2), 0)
+            val tileProvider = MapTileProviderBasic(applicationContext, campusTileSource)
+            val tilesOverlay = TilesOverlay(tileProvider, applicationContext)
+            mapView.overlays.add(tilesOverlay)
             mapView.setMultiTouchControls(true)
             mapView.zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
 
@@ -50,6 +59,12 @@ class MapActivity : ComponentActivity() {
             mapView.controller.setCenter(GeoPoint(46.518956, 6.566513))
             mapView
         })
+    }
+
+    class CampusTileSource(private val serverId: Int, private val floorId: Int) : OnlineTileSourceBase("EPFLCampusTileSource", 0, 18, 256, ".png", arrayOf()) {
+        override fun getTileURLString(pMapTileIndex: Long): String {
+            return "https://plan-epfl-tiles$serverId.epfl.ch/1.0.0/batiments/default/20160712/$floorId/3857/${MapTileIndex.getZoom(pMapTileIndex)}/${MapTileIndex.getY(pMapTileIndex)}/${MapTileIndex.getX(pMapTileIndex)}.png"
+        }
     }
 
     @Preview


### PR DESCRIPTION
This PR adds a layout of the EPFL campus tile source on top of the Open Street Maps tile source.