### PR TITLE
Change Code Climate argument count threshold to 6

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,9 @@ exclude_patterns:
 - "**/test/"
 - "**/androidTest/"
 - "**test"
+
+checks:
+  argument-count:
+    enabled: true
+    config:
+      threshold: 6


### PR DESCRIPTION
This PR changes the argument count threshold of Code Climate from 4 to 6.