### PR TITLE
Add a game menu to the map's heads-up display

### DIFF
--- a/app/src/androidTest/java/com/github/polypoly/app/map/MapActivityTest.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/map/MapActivityTest.kt
@@ -3,10 +3,16 @@ package com.github.polypoly.app.map
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.polypoly.app.RulesObject
+import com.github.polypoly.app.menu.ProfileActivity
+import com.github.polypoly.app.menu.SettingsActivity
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -19,34 +25,88 @@ class MapActivityTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<MapActivity>()
 
-    private val dropDownButton = composeTestRule.onNodeWithTag("dropDownButton")
+    private val otherPlayersAndGameDropDownButton = composeTestRule.onNodeWithTag("otherPlayersAndGameDropDownButton")
     private val gameInfoButton = composeTestRule.onNodeWithTag("gameInfoButton")
     private val playerInfoButton = composeTestRule.onNodeWithTag("playerInfoButton")
+    private val gameMenuDropDownButton = composeTestRule.onNodeWithTag("gameMenuDropDownButton")
+
+    private val menuButtonRules = composeTestRule.onNodeWithContentDescription("Show Rules")
+    private val menuButtonRankings = composeTestRule.onNodeWithContentDescription("Open Rankings")
+    private val menuButtonProfile = composeTestRule.onNodeWithContentDescription("Open Profile")
+    private val menuButtonSettings = composeTestRule.onNodeWithContentDescription("Open Settings")
+
+    private val rules = composeTestRule.onNodeWithText(RulesObject.rulesTitle)
 
     @Before
     fun setUp() {
         runBlocking { delay(5000) } // TODO: Find a better way to wait for the UI to update
     }
 
+    @Before
+    fun startIntents() { Intents.init() }
+
+    @After
+    fun releaseIntents() { Intents.release() }
+
     @Test
     fun hudIsDisplayed() {
-        dropDownButton.assertIsDisplayed()
+        otherPlayersAndGameDropDownButton.assertIsDisplayed()
         playerInfoButton.assertIsDisplayed()
+        gameMenuDropDownButton.assertIsDisplayed()
     }
 
     @Test
     fun gameInfoAndOtherPlayersInfoAreDisplayedOnDropDownButtonClick() {
         gameInfoButton.assertDoesNotExist()
-        dropDownButton.performClick()
+        otherPlayersAndGameDropDownButton.performClick()
         gameInfoButton.assertIsDisplayed()
     }
 
     @Test
     fun gameInfoAndOtherPlayersInfoAreCollapsedWhenDropDownButtonIsClickedAgain() {
-        dropDownButton.performClick()
+        otherPlayersAndGameDropDownButton.performClick()
         gameInfoButton.assertIsDisplayed()
-        dropDownButton.performClick()
+        otherPlayersAndGameDropDownButton.performClick()
         gameInfoButton.assertDoesNotExist()
+    }
+
+    @Test
+    fun gameMenuIsDisplayedOnDropDownButtonClick() {
+        gameMenuDropDownButton.performClick()
+        menuButtonRules.assertIsDisplayed()
+        menuButtonRankings.assertIsDisplayed()
+        menuButtonProfile.assertIsDisplayed()
+        menuButtonSettings.assertIsDisplayed()
+    }
+
+    @Test
+    fun gameMenuRulesButtonDisplaysRules() {
+        gameMenuDropDownButton.performClick()
+        menuButtonRules.performClick()
+        rules.assertIsDisplayed()
+    }
+
+    @Test
+    fun gameMenuRulesDismissOnOutsideClick() {
+        gameMenuDropDownButton.performClick()
+        menuButtonRules.performClick()
+        rules.assertIsDisplayed()
+        gameMenuDropDownButton.performClick()
+        rules.assertDoesNotExist()
+    }
+
+    @Test
+    fun gameMenuProfileButtonDisplaysActivity() {
+        gameMenuDropDownButton.performClick()
+        menuButtonProfile.performClick()
+        Intents.intended(IntentMatchers.hasComponent(ProfileActivity::class.java.name))
+    }
+
+    @Test
+    fun gameMenuSettingsButtonDisplaysActivity() {
+        gameMenuDropDownButton.performClick()
+        menuButtonSettings.performClick()
+        Intents.intended(IntentMatchers.hasComponent(SettingsActivity::class.java.name))
     }
 
     @Test

--- a/app/src/main/java/com/github/polypoly/app/map/MapActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/map/MapActivity.kt
@@ -58,6 +58,7 @@ import com.github.polypoly.app.BuildConfig
 import com.github.polypoly.app.R
 import com.github.polypoly.app.game.PlayerGlobalData
 import com.github.polypoly.app.map.LocationRepository.getZones
+import com.github.polypoly.app.menu.MenuComposable
 import com.github.polypoly.app.ui.theme.PolypolyTheme
 import com.github.polypoly.app.ui.theme.Shapes
 import com.github.polypoly.app.utils.Padding
@@ -508,6 +509,7 @@ class MapActivity : ComponentActivity() {
         HudPlayer(playerData)
         HudOtherPlayersAndGame(otherPlayersData, round)
         HudLocation(location = mapViewModel.closeLocation.value?.name ?: "")
+        HudGameMenu()
     }
 
     /**
@@ -688,6 +690,47 @@ class MapActivity : ComponentActivity() {
                 ) {
                     // TODO: Add information about other players
                     Text(text = "Other player info")
+                }
+            }
+        }
+    }
+
+    /**
+     * The HUD for the game menu, which is a button on the bottom left that expands and collapses
+     * the menu
+     */
+    @Composable
+    fun HudGameMenu() {
+        var openGameMenu by remember { mutableStateOf(false) }
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .padding(Padding.medium)
+                    .align(Alignment.BottomStart)
+            ) {
+                Column(Modifier.padding(Padding.medium)) {
+                    // The game menu slides in and out when the game menu button is pressed
+                    AnimatedVisibility(
+                        visible = openGameMenu,
+                    ) {
+                        Surface(
+                            color = MaterialTheme.colors.background,
+                            shape = Shapes.medium,
+                            modifier = Modifier
+                                .padding(Padding.medium)
+                        ) {
+                            MenuComposable.RowButtons()
+                        }
+                    }
+
+                    // The drop down button that expands and collapses the game menu
+                    HudButton(
+                        name = "gameMenuDropDownButton",
+                        onClick = { openGameMenu = !openGameMenu },
+                        icon_id = R.drawable.tmp_happysmile,
+                        description = "Expand or collapse the game menu"
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/github/polypoly/app/map/MapActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/map/MapActivity.kt
@@ -530,7 +530,8 @@ class MapActivity : ComponentActivity() {
     }
 
     /**
-     * The HUD for the player stats
+     * The HUD for the player stats, it displays basic information such as their balance,
+     * and a button shows complete information on click
      */
     @Composable
     fun HudPlayer(playerData: PlayerGlobalData) {
@@ -541,7 +542,7 @@ class MapActivity : ComponentActivity() {
                 modifier = Modifier
                     .padding(Padding.medium)
                     .background(MaterialTheme.colors.background, shape = Shapes.medium)
-                    .align(Alignment.BottomStart)
+                    .align(Alignment.BottomEnd)
             ) {
                 Row(Modifier.padding(Padding.medium)) {
                     HudButton(
@@ -576,7 +577,9 @@ class MapActivity : ComponentActivity() {
     }
 
     /**
-     * The HUD that shows the stats for other players and the game
+     * The HUD that shows the stats for other players and the game, it's a button on the top left
+     * that expands and collapses a tab that contains information about the game and the other
+     * players
      */
     @Composable
     fun HudOtherPlayersAndGame(otherPlayersData: List<PlayerGlobalData>, round: Int) {
@@ -589,17 +592,19 @@ class MapActivity : ComponentActivity() {
                     .align(Alignment.TopStart)
             ) {
                 Column(Modifier.padding(Padding.medium)) {
-                    // A drop down button that expands and collapses the stats for other players and the game
+                    // A drop down button that expands and collapses the stats for other players and
+                    // the game
                     ToggleIconButton(
-                        "dropDownButton",
+                        "otherPlayersAndGameDropDownButton",
                         "Expand or collapse the stats for other players and the game",
                         { isExpanded = !isExpanded },
                         isExpanded,
-                        R.drawable.tmp_happysmile,
+                        R.drawable.tmp_sadsmile,
                         R.drawable.tmp_happysmile
                     )
 
-                    // The stats for other players and the game slide in and out when the drop down button is pressed
+                    // The stats for other players and the game slide in and out when the drop down
+                    // button is pressed
                     AnimatedVisibility(
                         visible = isExpanded,
                     ) {
@@ -623,7 +628,8 @@ class MapActivity : ComponentActivity() {
     }
 
     /**
-     * The HUD for the game stats
+     * The HUD for the game stats, it displays basic information such as the current round,
+     * and a button shows complete information on click
      */
     @Composable
     fun HudGame(round: Int) {
@@ -660,7 +666,8 @@ class MapActivity : ComponentActivity() {
     }
 
     /**
-     * The HUD for the stats of other players
+     * The HUD for the stats of other players, it displays basic information such as their balance,
+     * and a button shows complete information on click
      */
     @Composable
     fun HudOtherPlayer(playerData: PlayerGlobalData) {


### PR DESCRIPTION
This PR adds a game menu to the map's heads-up display, in the form of a drop-down button that displays a row of menu buttons right above it with a slide-in animation.

I had to put this menu on the left of the screen instead of the player's information that I moved to the bottom right of the activity because when the menu is in the right, opening it causes triggers a re-layout of the box that encloses the drop-down button and the menu buttons, causing the drop-down button to instantenously jump on the left.

I added more documentation to the HUD.