### PR TITLE
Add MockDB instead of using real DB for tests

### DIFF
--- a/app/src/androidTest/java/com/github/polypoly/app/JoinGameLobbyActivityTest.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/JoinGameLobbyActivityTest.kt
@@ -65,9 +65,7 @@ class JoinGameLobbyActivityTest: PolyPolyTest(false, true) {
         composeTestRule.onNodeWithTag("JoinGameLobbyButton").performClick()
 
         // Check that a message that the group is full is displayed
-        // TODO : fix this test
-        //Thread.sleep(1000)
-        //composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.game_lobby_is_full)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.game_lobby_is_full)).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/polypoly/app/commons/MockDB.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/commons/MockDB.kt
@@ -4,6 +4,9 @@ import com.github.polypoly.app.network.IRemoteStorage
 import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KClass
 
+/**
+ * Mock version of RemoteDB for testing purpose
+ */
 class MockDB: IRemoteStorage {
 
     private val keysHierarchy: MutableMap<String, MutableList<String>> = mutableMapOf()
@@ -58,15 +61,16 @@ class MockDB: IRemoteStorage {
         for (index in 0 until hierarchy.size - 1) {
             val parent = hierarchy[index]
             val child = hierarchy[index + 1]
-            if (!keysHierarchy.containsKey(parent)) {
-                keysHierarchy[parent] = mutableListOf()
-            }
+            keysHierarchy.putIfAbsent(parent, mutableListOf())
             keysHierarchy[parent]!!.add(child)
         }
         data[keyCleaned] = value as Any
         return CompletableFuture.completedFuture(true)
     }
 
+    /**
+     * Clears all value in the mock database
+     */
     fun clear() {
         data.clear()
         keysHierarchy.clear()

--- a/app/src/androidTest/java/com/github/polypoly/app/commons/MockDB.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/commons/MockDB.kt
@@ -1,0 +1,74 @@
+package com.github.polypoly.app.commons
+
+import com.github.polypoly.app.network.IRemoteStorage
+import java.util.concurrent.CompletableFuture
+import kotlin.reflect.KClass
+
+class MockDB: IRemoteStorage {
+
+    private val keysHierarchy: MutableMap<String, MutableList<String>> = mutableMapOf()
+    private val data: MutableMap<String, Any> = mutableMapOf()
+
+    private fun cleanKey(key: String): String {
+        return key.removePrefix("/").removeSuffix("/")
+    }
+
+    override fun <T : Any> getValue(key: String, clazz: KClass<T>): CompletableFuture<T> {
+        val keyCleaned = cleanKey(key)
+        if (!data.containsKey(keyCleaned))
+            return CompletableFuture.failedFuture(IllegalAccessException("Invalid key $keyCleaned"))
+        @Suppress("UNCHECKED_CAST")
+        return CompletableFuture.completedFuture(data[cleanKey(key)] as T)
+    }
+
+    override fun <T : Any> getAllValues(key: String, clazz: KClass<T>): CompletableFuture<List<T>> {
+        val objs = mutableListOf<T>()
+        val parentKeyCleaned = cleanKey(key)
+        @Suppress("UNCHECKED_CAST")
+        for (child in keysHierarchy[parentKeyCleaned] ?: listOf())
+            objs.add(data["$parentKeyCleaned/$child"] as T)
+        return CompletableFuture.completedFuture(objs)
+    }
+
+    override fun getAllKeys(parentKey: String): CompletableFuture<List<String>> {
+        return CompletableFuture.completedFuture(keysHierarchy[cleanKey(parentKey)] ?: listOf())
+    }
+
+    override fun keyExists(key: String): CompletableFuture<Boolean> {
+        return CompletableFuture.completedFuture(data.containsKey(cleanKey(key)))
+    }
+
+    override fun <T> registerValue(key: String, value: T): CompletableFuture<Boolean> {
+        val keyCleaned = cleanKey(key)
+        if (data.containsKey(keyCleaned))
+            return CompletableFuture.failedFuture(IllegalAccessException("Registering a value already registered"))
+        return setValue(keyCleaned, value)
+    }
+
+    override fun <T> updateValue(key: String, value: T): CompletableFuture<Boolean> {
+        val keyCleaned = cleanKey(key)
+        if (!data.containsKey(keyCleaned))
+            return CompletableFuture.failedFuture(IllegalAccessException("Update a value not already registered"))
+        return setValue(keyCleaned, value)
+    }
+
+    override fun <T> setValue(key: String, value: T): CompletableFuture<Boolean> {
+        val keyCleaned = cleanKey(key)
+        val hierarchy = keyCleaned.split("/")
+        for (index in 0 until hierarchy.size - 1) {
+            val parent = hierarchy[index]
+            val child = hierarchy[index + 1]
+            if (!keysHierarchy.containsKey(parent)) {
+                keysHierarchy[parent] = mutableListOf()
+            }
+            keysHierarchy[parent]!!.add(child)
+        }
+        data[keyCleaned] = value as Any
+        return CompletableFuture.completedFuture(true)
+    }
+
+    fun clear() {
+        data.clear()
+        keysHierarchy.clear()
+    }
+}

--- a/app/src/androidTest/java/com/github/polypoly/app/menu/ProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/menu/ProfileActivityTest.kt
@@ -1,4 +1,4 @@
-/*package com.github.polypoly.app.menu
+package com.github.polypoly.app.menu
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -118,4 +118,4 @@ class ProfileActivityTest: PolyPolyTest(true, true) {
         composeTestRule.onNodeWithTag("emptySlot2").assertExists()
     }
 
-}*/
+}

--- a/app/src/androidTest/java/com/github/polypoly/app/menu/ProfileModifyingActicityTest.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/menu/ProfileModifyingActicityTest.kt
@@ -1,4 +1,4 @@
-/*package com.github.polypoly.app.menu
+package com.github.polypoly.app.menu
 
 import android.content.Intent
 import androidx.compose.ui.test.*
@@ -123,4 +123,4 @@ class ProfileModifyingActivityTest: LoggedInTest(true, true) {
 
         Intents.release()
     }
-}*/
+}

--- a/app/src/androidTest/java/com/github/polypoly/app/network/RemoteDBTest.kt
+++ b/app/src/androidTest/java/com/github/polypoly/app/network/RemoteDBTest.kt
@@ -1,20 +1,52 @@
 package com.github.polypoly.app.network
 
-import com.github.polypoly.app.commons.PolyPolyTest
 import com.github.polypoly.app.base.game.rules_and_lobby.GameLobby
 import com.github.polypoly.app.base.user.User
+import com.github.polypoly.app.commons.PolyPolyTest
 import com.github.polypoly.app.global.GlobalInstances.Companion.remoteDB
+import com.github.polypoly.app.global.GlobalInstances.Companion.remoteDBInitialized
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.*
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
 @RunWith(JUnit4::class)
-class RemoteDBTest: PolyPolyTest(true, false) {
+class RemoteDBTest: PolyPolyTest(false, false) {
+
+    private val rootTests = "test-hugo"
+    var dbRootRef: DatabaseReference
+
+    init {
+        val db = Firebase.database
+        try {
+            db.setPersistenceEnabled(false)
+        } catch (_: Exception) {}
+        remoteDB = RemoteDB(db, rootTests)
+        remoteDBInitialized = true
+
+        dbRootRef = db.reference.child(rootTests)
+    }
+
+    override fun _prepareTest() {
+        clearRealDB()
+    }
+
+    private fun clearRealDB() {
+        val timeout = CompletableFuture<Boolean>()
+        dbRootRef.removeValue()
+            .addOnSuccessListener {
+                timeout.complete(true)
+            }.addOnFailureListener(timeout::completeExceptionally)
+        timeout.get(TIMEOUT_DURATION, TimeUnit.SECONDS)
+    }
 
     private fun <T : Any> classCanBeStoredInDB(clazz: KClass<T>) {
         val noArgsKey = "no-args-obj"
@@ -28,7 +60,7 @@ class RemoteDBTest: PolyPolyTest(true, false) {
     }
 
     @Test
-    fun gameLobbyCanBççeStoredInDB() {
+    fun gameLobbyCanBeStoredInDB() {
         classCanBeStoredInDB(GameLobby::class)
     }
 

--- a/app/src/main/java/com/github/polypoly/app/SignInActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/SignInActivity.kt
@@ -28,6 +28,7 @@ import com.github.polypoly.app.base.user.User
 import com.github.polypoly.app.global.GlobalInstances.Companion.currentUser
 import com.github.polypoly.app.global.GlobalInstances.Companion.isSignedIn
 import com.github.polypoly.app.global.GlobalInstances.Companion.remoteDB
+import com.github.polypoly.app.global.GlobalInstances.Companion.remoteDBInitialized
 import com.github.polypoly.app.global.Settings.Companion.DB_GAME_LOBIES_PATH
 import com.github.polypoly.app.global.Settings.Companion.DB_USERS_PROFILES_PATH
 import com.github.polypoly.app.menu.kotlin.GameMusic
@@ -50,9 +51,11 @@ class SignInActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // Global initialization of the database
-        val db = Firebase.database
-        remoteDB = RemoteDB(db, "live")
-        // addFakeDataToDB() // < -- uncomment this line to add fake data to the DB
+        if (!remoteDBInitialized) { // Check if a test already initialized the remote storage
+            val db = Firebase.database
+            remoteDB = RemoteDB(db, "live")
+//            addFakeDataToDB() // < -- uncomment this line to add fake data to the DB
+        }
 
         firebaseAuth = FirebaseAuth.getInstance()
         isSignedIn = false

--- a/app/src/main/java/com/github/polypoly/app/global/GlobalInstances.kt
+++ b/app/src/main/java/com/github/polypoly/app/global/GlobalInstances.kt
@@ -1,5 +1,6 @@
 package com.github.polypoly.app.global
 
+import com.github.polypoly.app.network.IRemoteStorage
 import com.github.polypoly.app.network.RemoteDB
 import com.google.firebase.auth.FirebaseUser
 
@@ -10,7 +11,8 @@ import com.google.firebase.auth.FirebaseUser
  */
 class GlobalInstances {
     companion object {
-        lateinit var remoteDB: RemoteDB
+        lateinit var remoteDB: IRemoteStorage
+        var remoteDBInitialized = false
 
         var currentUser : FirebaseUser? = null
         var isSignedIn = false


### PR DESCRIPTION
Using the real database for testing purpose may lead to side effects / inconsistent behaviors.
This PR adds the class MockDB as a mock version of RemoteDB, aiming at being used in all tests instead (apart from RemoteDB tests ofc).