### PR TITLE
Fix game composables z-order

### DIFF
--- a/app/src/main/java/com/github/polypoly/app/ui/game/MapActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/ui/game/MapActivity.kt
@@ -114,6 +114,7 @@ class MapActivity : ComponentActivity() {
                     MapView()
                     BuildingInfoUIComponent()
                     RollDiceDialog()
+                    RollDiceButton()
                     Hud(
                         Player(
                             user = User(
@@ -159,7 +160,6 @@ class MapActivity : ComponentActivity() {
                             )),
                         16
                     )
-                    RollDiceButton()
                 }
             }
         }


### PR DESCRIPTION
This is a straight-forward fix for the roll dice button being incorrectly displayed on top of the game menu button.

> In Compose, the order in which you add composables to a parent determines their z-order, with later composables appearing on top of earlier ones.

<img src="https://user-images.githubusercontent.com/56200813/235320292-902dfb37-1e3c-4eee-8914-21f9f16498ed.png" width="25%" height="25%">)