### PR TITLE
Change minimum sdk to ensure cirrus uses the right one

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ env:
   CC_TEST_REPORTER_ID: ENCRYPTED[729d703dabe07f9797508fd1d6d4e46fa7fd4c6784c7683f8544638198a3489733bdd1aa176faafa693e87b66a37edda]
 
 container:
-  image: cirrusci/android-sdk:30
+  image: cirrusci/android-sdk:33
   cpu: 4
   memory: 16G
   kvm: true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.github.polypoly.app"
-        minSdk 26
+        minSdk 33
         targetSdk 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Attempt to fix cirrus failure that sometimes cannot find the `failedFuture` function: minimum sdk is supposed to be 31 now (see [here](https://developer.android.com/reference/java/util/concurrent/CompletableFuture#failedFuture(java.lang.Throwable)))