### PR TITLE
Fix max round duration

### DIFF
--- a/app/src/main/java/com/github/polypoly/app/base/menu/lobby/GameParameters.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/menu/lobby/GameParameters.kt
@@ -30,7 +30,7 @@ data class GameParameters (
             throw java.lang.IllegalArgumentException("At least 2 players are needed for a game (provided $minimumNumberOfPlayers)")
         if (maximumNumberOfPlayers < minimumNumberOfPlayers)
             throw java.lang.IllegalArgumentException("Maximum number of players $maximumNumberOfPlayers must be greater than the minimum number $minimumNumberOfPlayers")
-        if (roundDuration <= 0 || roundDuration >= GameLobbyConstants.RoundDurations.getMaxRoundDuration().toMinutes())
+        if (roundDuration <= 0 || roundDuration > GameLobbyConstants.RoundDurations.getMaxRoundDuration().toMinutes())
             throw java.lang.IllegalArgumentException("Invalid game duration$roundDuration")
     }
 }


### PR DESCRIPTION
Just a very simple fix for a bug I encountered while debugging something else: the app would throw an `IllegalArgumentException` if the maximum round duration was set on game lobby creation.