### PR TITLE
Implement passive capital gain in landlord mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.READ_TOASTS"

--- a/app/src/main/java/com/github/polypoly/app/base/game/Game.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/game/Game.kt
@@ -26,7 +26,7 @@ class Game private constructor(
     val dateBegin: Long = System.currentTimeMillis(),
 ) {
 
-    private val inGameLocations: List<InGameLocation> = rules.gameMap.flatMap { zone ->
+    val inGameLocations: List<InGameLocation> = rules.gameMap.flatMap { zone ->
         zone.locationProperties.map { location ->
             InGameLocation(
                 locationProperty = location,

--- a/app/src/main/java/com/github/polypoly/app/base/game/location/LocationProperty.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/game/location/LocationProperty.kt
@@ -1,5 +1,6 @@
 package com.github.polypoly.app.base.game.location
 
+import android.location.Location
 import org.osmdroid.util.GeoPoint
 
 /**
@@ -44,4 +45,18 @@ data class LocationProperty(
      *   @return the [GeoPoint] representing the position of the [LocationProperty] on the map.
      */
     fun position(): GeoPoint = GeoPoint(latitude, longitude)
+
+    /**
+     *  The distance between the [LocationProperty] and a [Location].
+     *
+     *  @param location the [Location] to compare with.
+     *
+     *  @return the distance between the [LocationProperty] and the [Location].
+     */
+    fun distanceTo(location: Location): Float {
+        val locationPropertyLocation = Location("")
+        locationPropertyLocation.latitude = latitude
+        locationPropertyLocation.longitude = longitude
+        return location.distanceTo(locationPropertyLocation)
+    }
 }

--- a/app/src/main/java/com/github/polypoly/app/base/game/service/LocationService.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/game/service/LocationService.kt
@@ -1,0 +1,94 @@
+package com.github.polypoly.app.base.game.service
+
+import android.Manifest
+import android.app.Service
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.location.Location
+import android.os.Build
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.ActivityCompat
+import com.github.polypoly.app.utils.Constants
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+
+/**
+ * A service that runs in the background, receives location updates and processes them
+ */
+abstract class LocationService: Service() {
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+
+    private val locationCallback = object : LocationCallback() {
+        override fun onLocationResult(locationResult: LocationResult) {
+            locationResult.lastLocation?.let { location ->
+                // Process the received location update
+                processLocationUpdate(location)
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startLocationUpdates()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        fusedLocationProviderClient.removeLocationUpdates(locationCallback)
+    }
+
+    private fun startLocationUpdates() {
+        val locationRequest = LocationRequest.create().apply {
+            interval = Constants.LANDLORD_TAX_POLL_RATE * 1000 // Update interval in milliseconds
+            fastestInterval = Constants.LANDLORD_TAX_POLL_RATE * 1000 // Fastest update interval in milliseconds
+            priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+        }
+
+        // Check that location permissions are granted
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
+        // Check that background location is enabled on Android 10+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+
+        // Request location updates while registering the callback
+        fusedLocationProviderClient.requestLocationUpdates(
+            locationRequest,
+            locationCallback,
+            Looper.getMainLooper()
+        )
+    }
+
+    /**
+     * Process a location update
+     *
+     * @param location The new location
+     */
+    abstract fun processLocationUpdate(location: Location)
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+}

--- a/app/src/main/java/com/github/polypoly/app/base/game/service/TaxService.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/game/service/TaxService.kt
@@ -10,24 +10,16 @@ import com.github.polypoly.app.utils.Constants
  */
 class TaxService: LocationService() {
     override fun processLocationUpdate(location: Location) {
-        val playerLocation = location // For clarity
+        val playerLocation = location
 
         // Iterate through all the locations and check if the player is close enough to interact
         for (inGameLocation in GameRepository.game?.inGameLocations!!) {
-            // Create a location object from the in-game location
-            val propertyLocation = Location("").apply {
-                latitude = inGameLocation.locationProperty.latitude
-                longitude = inGameLocation.locationProperty.longitude
-            }
-
             // Compute distance between player and location in meters
-            val distance = playerLocation.distanceTo(propertyLocation)
+            val distance = inGameLocation.locationProperty.distanceTo(playerLocation)
 
             if (inGameLocation.owner != null && inGameLocation.owner != GameRepository.player && distance <= Constants.MAX_INTERACT_DISTANCE) {
-                /**
-                 * Perform tax payment and money transfer if the player is close enough to a location
-                 * that is owned by another player.
-                 */
+                /* Perform tax payment and money transfer if the player is close enough to a location
+                 * that is owned by another player. */
                 val taxAmount = inGameLocation.currentTax()
                 GameRepository.player?.loseMoney(taxAmount)
                 inGameLocation.owner?.earnMoney(taxAmount)

--- a/app/src/main/java/com/github/polypoly/app/base/game/service/TaxService.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/game/service/TaxService.kt
@@ -1,0 +1,37 @@
+package com.github.polypoly.app.base.game.service
+
+import android.location.Location
+import com.github.polypoly.app.data.GameRepository
+import com.github.polypoly.app.utils.Constants
+
+/**
+ * A service that runs in the background, receives location updates and taxes the [Player]
+ * if they are in a [LocationProperty] that is owned by another [Player].
+ */
+class TaxService: LocationService() {
+    override fun processLocationUpdate(location: Location) {
+        val playerLocation = location // For clarity
+
+        // Iterate through all the locations and check if the player is close enough to interact
+        for (inGameLocation in GameRepository.game?.inGameLocations!!) {
+            // Create a location object from the in-game location
+            val propertyLocation = Location("").apply {
+                latitude = inGameLocation.locationProperty.latitude
+                longitude = inGameLocation.locationProperty.longitude
+            }
+
+            // Compute distance between player and location in meters
+            val distance = playerLocation.distanceTo(propertyLocation)
+
+            if (inGameLocation.owner != null && inGameLocation.owner != GameRepository.player && distance <= Constants.MAX_INTERACT_DISTANCE) {
+                /**
+                 * Perform tax payment and money transfer if the player is close enough to a location
+                 * that is owned by another player.
+                 */
+                val taxAmount = inGameLocation.currentTax()
+                GameRepository.player?.loseMoney(taxAmount)
+                inGameLocation.owner?.earnMoney(taxAmount)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/polypoly/app/base/menu/lobby/GameParameters.kt
+++ b/app/src/main/java/com/github/polypoly/app/base/menu/lobby/GameParameters.kt
@@ -3,7 +3,6 @@ package com.github.polypoly.app.base.menu.lobby
 import com.github.polypoly.app.base.game.location.LocationPropertyRepository
 import com.github.polypoly.app.base.game.location.Zone
 import com.github.polypoly.app.ui.menu.lobby.GameLobbyConstants
-import com.github.polypoly.app.base.game.location.LocationPropertyRepository
 
 /**
  * A class that represent the parameters of a [Game]

--- a/app/src/main/java/com/github/polypoly/app/ui/game/GameActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/ui/game/GameActivity.kt
@@ -55,7 +55,7 @@ import timber.log.Timber
  * Activity for displaying the map used in the game.
  */
 class GameActivity : ComponentActivity() {
-    private val gameModel: GameViewModel by viewModels { GameViewModel.Factory }
+    val gameModel: GameViewModel by viewModels { GameViewModel.Factory }
     private lateinit var taxService: Intent
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/polypoly/app/ui/game/GameActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/ui/game/GameActivity.kt
@@ -95,12 +95,6 @@ class GameActivity : ComponentActivity() {
                     if (GameRepository.game?.rules?.gameMode == GameMode.LANDLORD) {
                         BackgroundLocationPermissionHandler { startTaxService() }
                     }
-                    MapUI.MapView(mapViewModel, interactingWithProperty)
-                    PropertyInteractUIComponent()
-                    if (player?.playerState!!.value == PlayerState.ROLLING_DICE) {
-                        RollDiceDialog()
-                        RollDiceButton()
-                    }
                     MapUI.MapView(mapViewModel, gameModel)
                     PropertyInteractUIComponent(gameModel, mapViewModel)
                     DiceRollUI(gameModel, mapViewModel)
@@ -164,34 +158,6 @@ class GameActivity : ComponentActivity() {
         // flag to show the building info dialog
         val interactingWithProperty = mutableStateOf(false)
 
-        /**
-         * Updates the distance of all markers and returns the closest one.
-         *
-         * @return the closest location or null if there are no locations close enough to the player
-         */
-        fun updateAllDistancesAndFindClosest(
-            mapView: MapView,
-            myLocation: GeoPoint
-        ): LocationProperty? {
-            fun markersOf(mapView: MapView): List<Marker> {
-                return mapView.overlays.filterIsInstance<Marker>()
-            }
-
-            var closestLocationProperty = null as LocationProperty?
-            for (marker in markersOf(mapView)) {
-                val markerLocation = mapViewModel.markerToLocationProperty[marker]!!
-                if (closestLocationProperty == null ||
-                    myLocation.distanceToAsDouble(markerLocation.position())
-                    < myLocation.distanceToAsDouble(closestLocationProperty.position())
-                ) {
-                    closestLocationProperty = markerLocation
-                }
-            }
-            if (myLocation.distanceToAsDouble(closestLocationProperty!!.position()) > Constants.MAX_INTERACT_DISTANCE)
-                closestLocationProperty = null
-
-            return closestLocationProperty
-        }
     }
 
     @Composable

--- a/app/src/main/java/com/github/polypoly/app/ui/game/GameActivity.kt
+++ b/app/src/main/java/com/github/polypoly/app/ui/game/GameActivity.kt
@@ -1,42 +1,158 @@
 package com.github.polypoly.app.ui.game
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.*
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.github.polypoly.app.base.game.location.LocationProperty
+import com.github.polypoly.app.base.game.service.TaxService
+import com.github.polypoly.app.base.menu.lobby.GameMode
+import com.github.polypoly.app.data.GameRepository
 import com.github.polypoly.app.models.game.GameViewModel
 import com.github.polypoly.app.ui.map.MapUI
 import com.github.polypoly.app.ui.map.MapViewModel
 import com.github.polypoly.app.ui.theme.PolypolyTheme
+import com.github.polypoly.app.utils.Constants
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
+import timber.log.Timber
 
 /**
  * Activity for displaying the map used in the game.
  */
 class GameActivity : ComponentActivity() {
-
     private val gameModel: GameViewModel by viewModels { GameViewModel.Factory }
+    private lateinit var taxService: Intent
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent { GameActivityContent() }
+    }
+
+    @Composable
+    fun BackgroundLocationPermissionHandler(callback: () -> Unit) {
+        var acknowledgePermissionDenial by remember { mutableStateOf(false) }
+        when {
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED -> {
+                Timber.tag("GameActivity").d("Background location permission granted")
+                callback()
+            }
+            shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_BACKGROUND_LOCATION) -> {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Text(
+                        text = "Background location permission is required to passively tax players if they are in a location property that is owned by another player.",
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("background_location_permission_rationale")
+                    )
+                    Button(
+                        onClick = {
+                            requestBackgroundLocationPermission(grantCallback = callback, denyCallback = {
+                                acknowledgePermissionDenial = true
+                            })
+                        }
+                    ) {
+                        Text(text = "OK")
+                    }
+                }
+            }
+            else -> {
+                requestBackgroundLocationPermission(grantCallback = callback, denyCallback = {
+                    acknowledgePermissionDenial = true
+                })
+            }
+        }
+
+        // TODO: Disable taxing for everyone if one user doesn't give permission to make it fair.
+        if (acknowledgePermissionDenial) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Text(
+                    text = "Background location permission is required to passively tax players if they are in a location property that is owned by another player.",
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .testTag("background_location_permission_denied")
+                )
+                Button(
+                    onClick = {
+                        requestBackgroundLocationPermission(grantCallback = callback, denyCallback = {
+                            acknowledgePermissionDenial = true
+                        })
+                    }
+                ) {
+                    Text(text = "OK")
+                }
+            }
+        }
+    }
+
+    private fun requestBackgroundLocationPermission(grantCallback: () -> Unit, denyCallback: () -> Unit) {
+        val requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+                if (isGranted) {
+                    grantCallback()
+                }
+                else {
+                    denyCallback()
+                }
+            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            requestPermissionLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Stop the tax service if the game mode is landlord.
+        if (GameRepository.game?.rules?.gameMode == GameMode.LANDLORD) {
+            stopTaxService()
+        }
+    }
+
+    private fun startTaxService() {
+        taxService = Intent(this, TaxService::class.java)
+        startForegroundService(taxService)
+    }
+
+    private fun stopTaxService() {
+        stopService(taxService)
     }
 
     @Composable
@@ -53,6 +169,13 @@ class GameActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
+                    /**
+                     * If the game mode is landlord, start the tax service to passively tax players
+                     * if they are in a location property that is owned by another player.
+                     */
+                    if (GameRepository.game?.rules?.gameMode == GameMode.LANDLORD) {
+                        BackgroundLocationPermissionHandler { startTaxService() }
+                    }
                     MapUI.MapView(mapViewModel, interactingWithProperty)
                     PropertyInteractUIComponent()
                     if (player?.playerState!!.value == PlayerState.ROLLING_DICE) {
@@ -117,9 +240,6 @@ class GameActivity : ComponentActivity() {
         // flag to show the building info dialog
         val interactingWithProperty = mutableStateOf(false)
 
-        //used to determine if the player is close enough to a location to interact with it
-        private const val MAX_INTERACT_DISTANCE = 10.0 // meters
-
         /**
          * Updates the distance of all markers and returns the closest one.
          *
@@ -143,7 +263,7 @@ class GameActivity : ComponentActivity() {
                     closestLocationProperty = markerLocation
                 }
             }
-            if (myLocation.distanceToAsDouble(closestLocationProperty!!.position()) > MAX_INTERACT_DISTANCE)
+            if (myLocation.distanceToAsDouble(closestLocationProperty!!.position()) > Constants.MAX_INTERACT_DISTANCE)
                 closestLocationProperty = null
 
             return closestLocationProperty

--- a/app/src/main/java/com/github/polypoly/app/utils/Constants.kt
+++ b/app/src/main/java/com/github/polypoly/app/utils/Constants.kt
@@ -4,4 +4,9 @@ package com.github.polypoly.app.utils
  * Constants used in the app
  */
 class Constants {
+    companion object {
+        // Used to determine if the player is close enough to a location to interact with it
+        const val MAX_INTERACT_DISTANCE = 10.0 // In meters
+        const val LANDLORD_TAX_POLL_RATE: Long = 60 // In seconds
+    }
 }


### PR DESCRIPTION
This implements a tax service that the game activity launches in the background to keep track of the player's location and tax them if they come near a location owned by another player.

The app requires background location permission that it requests to the user, and starts the service if granted, otherwise it acknowledges that the user declined to grant permission.

There are constants for the polling rate of the tax service and the distance to which it is considered that the player interacts with a building.